### PR TITLE
Patch 1

### DIFF
--- a/virtualLightSensor/virtualLightSensor-ES6.yaml
+++ b/virtualLightSensor/virtualLightSensor-ES6.yaml
@@ -51,7 +51,7 @@ triggers:
     type: core.ItemStateChangeTrigger
   - id: "2"
     configuration:
-      itemName: "{{cloudiness}}"
+      itemName: "{{}}"
     type: core.ItemStateChangeTrigger
 conditions: []
 actions:
@@ -121,10 +121,16 @@ actions:
 
 
         function itemState(event, name) {
+          try {
             // if the event was triggered by the item, make sure to return the event state
             if (event && (event.itemName === name))
-                return event.itemState.toString();
-            return items.getItem(name).state;
+                return Quantity(event.itemState.toString());
+            return items[name].quantityState;
+          }
+          // failed to convert the state to a QT, it's probably NULL or UNDEF or the wrong type
+          catch(e) {
+            return null;
+          }
         }
 
 
@@ -133,46 +139,46 @@ actions:
 
         var radiationState = itemState(this.event, TOTAL_RADIATION);
 
-        if (radiationState !== "NULL" && radiationState !== "UNDEF") {
+        if (radiationState !== null) {
           // update lux
-          var totalRadiation = Quantity(radiationState).toUnit("W/m^2").float;
-          var lux = totalRadiation / 0.0079;              // Radiation in Lux. 1 Lux = 0.0079 W/m^2
+          let totalRadiation = radiationState.toUnit("W/m^2").float;
+          let lux = totalRadiation / 0.0079;              // Radiation in Lux. 1 Lux = 0.0079 W/m^2
           if (LUX) {
-              items.getItem(LUX).postUpdate(lux + " lx");
+              items[LUX].postUpdate(lux + " lx");
           }
 
-          var cloudinessState = itemState(this.event, CLOUDINESS);
-          if (cloudinessState !== "NULL" && cloudinessState !== "UNDEF") {
+          let cloudinessState = itemState(this.event, CLOUDINESS);
+          if (cloudinessState !== null) {
             // update weighted lux
             // Okta
-            var cloudiness = parseInt(cloudinessState);
-            var okta = cloudiness;
+            let cloudiness = cloudinessState.int;
+            let okta = cloudinessState.int;
             if (PERCENT && (cloudiness !== 0)) {
-              okta = OKTA_TABLE.reduce(function (result, element) {
-                return (cloudiness >= element[0]) ? element[1] : result;
-              })
+              okta = OKTA_TABLE.reduce((result, element) => (cloudiness >= element[0]) ? element[1] : result);
             }
             // Factor of mitigation for the cloud layer (clearSkyIndex = kc)
-            clearSkyIndex = 1.0 - 0.75 * Math.pow((okta/8.0), 3.4);
+            let clearSkyIndex = 1.0 - 0.75 * Math.pow((okta/8.0), 3.4);
             logger.debug("Kc {}", clearSkyIndex);
             var weightedLux = lux * clearSkyIndex;         // Radiation of the sun with compensation for the cloud layer
             if (WEIGHTED_LUX) {
-                items.getItem(WEIGHTED_LUX).postUpdate(weightedLux + " lx");
+                items[WEIGHTED_LUX].postUpdate(weightedLux + " lx");
             }
           } else {
-            logger.warn("Cannot calculate outside light, total cloudiness input undefined")
+            logger.warn("Cannot calculate outside light, total cloudiness input undefined or of the wrong format")
             if (WEIGHTED_LUX) {
-                items.getItem(WEIGHTED_LUX).postUpdate("UNDEF");
+                items[WEIGHTED_LUX].postUpdate("UNDEF");
             }
           }  
         } else {
-          logger.warn("Cannot calculate outside light, total radiation input undefined")
+          logger.warn("Cannot calculate outside light, total radiation input undefined or of the wrong format")
           if (LUX) {
-              items.getItem(LUX).postUpdate("UNDEF");
+              items[LUX].postUpdate("UNDEF");
           }
           if (WEIGHTED_LUX) {
-              items.getItem(WEIGHTED_LUX).postUpdate("UNDEF");
+              items[WEIGHTED_LUX].postUpdate("UNDEF");
           }
         }
+
+
 
     type: script.ScriptAction

--- a/virtualLightSensor/virtualLightSensor-ES6.yaml
+++ b/virtualLightSensor/virtualLightSensor-ES6.yaml
@@ -51,7 +51,7 @@ triggers:
     type: core.ItemStateChangeTrigger
   - id: "2"
     configuration:
-      itemName: "{{}}"
+      itemName: "{{cloudiness}}"
     type: core.ItemStateChangeTrigger
 conditions: []
 actions:


### PR DESCRIPTION
While debugging a problem (which ended up being that I used the wrong type of Item) I added a few changes to the rule template to catch that case and generate a slightly more meaningful error I changed things around just a little bit to use a try/catch and the `quantityState` from the Item in `itemState`, returning `null` if the state cannot be converted. 

The other changes are just stylistic and I can remove them if desired. 

I also think a slight reordering can make the code more concise (i.e. check for WEIGHTED_LUX up front and skip all the cloudiness stuff entirely if it's not defined) but wanted to limit my changes to just cover the error message stuff.